### PR TITLE
Use device=all to allow for ripping physical media

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -5,7 +5,7 @@
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [
-        "--device=dri",
+        "--device=all",
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",


### PR DESCRIPTION
Without this, you can't e.g. rip DVDs with HandBrake. It still can't handle encrypted media due to missing libdvdcss, but it's an improvement nonetheless.