### PR TITLE
Update gnome runtime to 41

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [


### PR DESCRIPTION
This will match what majority of apps use right now, therefore save some space and bandwidth for users. It's also better supported than older one.