### PR TITLE
Update GNOME runtime version to 42

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [


### PR DESCRIPTION
Right now, we get a deprecation warning when updating Handbrake:

```text
$ flatpak update                              
Looking for updates…
Info: org.gnome.Sdk//41 is end-of-life, with reason:
   The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
Info: org.gnome.Platform//41 is end-of-life, with reason:
   The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
   fr.handbrake.ghb, org.freedesktop.Piper
Nothing to do.
```

It should not be an issue to bump the runtime version as the runtime image is retro-compatible with previous GNOME runtimes (I was wondering and tried it myself on my project, [Diffuse](https://github.com/MightyCreak/diffuse), and it worked flawlessly).