### PR TITLE
Update org.gnome.Platform to version 45

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [

--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -163,12 +163,12 @@
             ],
             "modules": [],
             "build-options": {
-                "append-path": "/usr/lib/sdk/llvm14/bin",
-                "prepend-ld-library-path": "/usr/lib/sdk/llvm14/lib"
+                "append-path": "/usr/lib/sdk/llvm17/bin",
+                "prepend-ld-library-path": "/usr/lib/sdk/llvm17/lib"
             }
         }
     ],
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm14"
+        "org.freedesktop.Sdk.Extension.llvm17"
     ]
 }


### PR DESCRIPTION
The GNOME 43 runtime is no longer supported as of September 20, 2023