### PR TITLE
New HandBrake release 1.7.2

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -12,7 +12,6 @@
         "--filesystem=host",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
-        "--filesystem=xdg-config/gtk-3.0",
         "--talk-name=org.gtk.vfs.*",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.UPower",

--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -76,8 +76,8 @@
             ],
             "sources": [
                 {
-                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.7.1/HandBrake-1.7.1-source.tar.bz2",
-                    "sha256": "733e42c8f254f6c2f8f6b40f0d3572fd49167ebf30742beae605effa16939edc",
+                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.7.2/HandBrake-1.7.2-source.tar.bz2",
+                    "sha256": "6a0fa23420483a2d74e58f0ad9944931d8f2e65bee63cf17333cbd9cb560ba93",
                     "type": "archive",
                     "strip-components": 1
                 },


### PR DESCRIPTION
Updated to the latest handbrake release using the directions in the README.

bot,build
