### PR TITLE
update runtime org.gnome.Platform (from 46) to 47

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [


### PR DESCRIPTION
update runtime org.gnome.Platform (from 46) to 47