### PR TITLE
Add Missing VCN functionality back into the build.

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -65,6 +65,7 @@
                 "--enable-qsv",
                 "--enable-nvenc",
                 "--enable-nvdec",
+                "--enable-vce",
                 "--enable-libdovi"
             ],
             "build-options": {


### PR DESCRIPTION
This should not have been removed from the 1.10.0 update. 