### PR TITLE
Update HandBrake to 1.10.1

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -9,6 +9,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--socket=pulseaudio",
         "--filesystem=host",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
@@ -78,8 +79,8 @@
             ],
             "sources": [
                 {
-                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.10.0/HandBrake-1.10.0-source.tar.bz2",
-                    "sha256": "f931012ee251113d996b61aceaaef57165efcc5ea5a2705efffc4265f6b53d26",
+                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.10.1/HandBrake-1.10.1-source.tar.bz2",
+                    "sha256": "eafa87d64b99c457240675f6b89a7f6aa3c1eb56352ec057a0a0949ba449fe8e",
                     "type": "archive",
                     "strip-components": 1
                 },


### PR DESCRIPTION

Generated with:

```
./configure --flatpak --enable-qsv --enable-vce --enable-nvdec
cd build
make pkg.create.flathub \
 HB_URL=https://github.com/HandBrake/HandBrake/releases/download/1.10.1/HandBrake-1.10.1-source.tar.bz2 \
 HB_SHA256=eafa87d64b99c457240675f6b89a7f6aa3c1eb56352ec057a0a0949ba449fe8e
```