### PR TITLE
Update HandBrake to 1.10.2

### DIFF
--- a/fr.handbrake.ghb.json
+++ b/fr.handbrake.ghb.json
@@ -79,8 +79,8 @@
             ],
             "sources": [
                 {
-                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.10.1/HandBrake-1.10.1-source.tar.bz2",
-                    "sha256": "eafa87d64b99c457240675f6b89a7f6aa3c1eb56352ec057a0a0949ba449fe8e",
+                    "url": "https://github.com/HandBrake/HandBrake/releases/download/1.10.2/HandBrake-1.10.2-source.tar.bz2",
+                    "sha256": "c65e1cc4f8cfc36c24107b92c28d60e71ef185ec983e9a5841facffafea5f8db",
                     "type": "archive",
                     "strip-components": 1
                 },
@@ -120,11 +120,11 @@
                     "dest-filename": "dav1d-1.5.1.tar.bz2"
                 },
                 {
-                    "url": "https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v3.1.0.tar.gz",
-                    "sha256": "3999586c261dc3d8690fd1489fc74da4e0fdff9159c8ce2b76ddfac001ad96d3",
+                    "url": "https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v3.1.2.tar.gz",
+                    "sha256": "d0d73bfea42fdcc1222272bf2b0e2319e9df5574721298090c3d28315586ecb1",
                     "type": "file",
                     "dest": "download",
-                    "dest-filename": "SVT-AV1-v3.1.0.tar.gz"
+                    "dest-filename": "SVT-AV1-v3.1.2.tar.gz"
                 },
                 {
                     "url": "https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/zimg-snapshot-20250624.tar.gz",


### PR DESCRIPTION


```
./configure --flatpak --enable-qsv --enable-vce --enable-nvdec
cd build
make pkg.create.flathub \
 HB_URL=https://github.com/HandBrake/HandBrake/releases/download/1.10.2/HandBrake-1.10.2-source.tar.bz2 \
 HB_SHA256=c65e1cc4f8cfc36c24107b92c28d60e71ef185ec983e9a5841facffafea5f8db
```